### PR TITLE
Updated write_image to use std::result::Result

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,7 @@ use std::fs::File;
 /// Write the buffer `pixels`, whose dimensions are given by `bounds`, to the
 /// file named `filename`.
 fn write_image(filename: &str, pixels: &[u8], bounds: (usize, usize))
-    -> Result<(), std::io::Error>
+    -> std::result::Result<(), std::io::Error>
 {
     let output = File::create(filename)?;
 


### PR DESCRIPTION
Updated `write_image()` to use `std::result::Result` instead of the default `std::io::Result` that wouldn't compile.