### PR TITLE
Update num crate to 0.4.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Jim Blandy <jimb@red-bean.com>"]
 edition = "2018"
 
 [dependencies]
-num = "0.4"
+num = "0.4.1"
 image = "0.13.0"
 rayon = "1"


### PR DESCRIPTION
Executing Cargo build fails under Rustc version 1.75.0.  need to modify the num version to 0.4.1 to fix the problem.